### PR TITLE
feat(auth): Authentication and Login UI

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:8000/api/v1
+VITE_API_BASE_URL=http://localhost:8000/api

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from './contexts';
+import ProtectedRoute from './components/ProtectedRoute';
 
 import HomePage from './pages/public/HomePage';
+import LoginPage from './pages/LoginPage';
+import LogoutPage from './pages/LogoutPage';
 import AdminDashboard from './pages/admin/AdminDashboard';
 
 
@@ -12,19 +16,28 @@ const App: React.FC = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        {/* <Layout> */}
+        <AuthProvider>
           <Routes>
             {/* --- Public Routes --- */}
             <Route path="/" element={<HomePage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/logout" element={<LogoutPage />} />
 
             {/* --- Admin Routes --- */}
-            <Route path="/admin" element={<AdminDashboard />} />
-      
+            <Route
+              path="/admin"
+              element={
+                <ProtectedRoute requiredRole="ADMIN">
+                  <AdminDashboard />
+                </ProtectedRoute>
+              }
+            />
             
+
             {/* --- Catch-all 404 Route --- */}
             {/* <Route path="*" element={<NotFoundPage />} /> */}
           </Routes>
-        {/* </Layout> */}
+        </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>
   );

--- a/frontend/src/actions/useAuth.ts
+++ b/frontend/src/actions/useAuth.ts
@@ -1,1 +1,48 @@
-// Authentication hooks
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { authApi } from '../api/auth.api';
+
+export const currentUserQueryKey = ['auth', 'me'];
+
+export const useCurrentUser = () => {
+  return useQuery({
+    queryKey: currentUserQueryKey,
+    queryFn: authApi.getCurrentUser,
+    enabled: !!localStorage.getItem('accessToken'),
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    retry: false,
+  });
+};
+
+export const useLogin = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ email, password }: { email: string; password: string }) =>
+      authApi.login(email, password),
+    onSuccess: (data) => {
+      // Storing tokens in localStorage is vulnerable to XSS attacks
+      // Consider using httpOnly cookies
+      localStorage.setItem('accessToken', data.access);
+      localStorage.setItem('refreshToken', data.refresh);
+      queryClient.invalidateQueries({ queryKey: currentUserQueryKey });
+    },
+  });
+};
+
+export const useLogout = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const refreshToken = localStorage.getItem('refreshToken');
+      if (refreshToken) {
+        await authApi.logout(refreshToken);
+      }
+    },
+    // Use onSettled (not onSuccess) to ensure local logout happens even if API call fails
+    // Users can always log out locally even if network is down
+    onSettled: () => {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      queryClient.removeQueries({ queryKey: currentUserQueryKey });
+    },
+  });
+};

--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -7,13 +7,88 @@ const apiClient = axios.create({
   },
 });
 
-// Optional: Interceptor to add auth token to requests
+// Request interceptor to add auth token to requests
 apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('authToken'); // Or get from context
+  const token = localStorage.getItem('accessToken');
   if (token) {
-    config.headers.Authorization = `Token ${token}`;
+    config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
+
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (value?: unknown) => void;
+  reject: (reason?: unknown) => void;
+}> = [];
+
+const processQueue = (error: unknown, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // If error is 401 and we haven't tried to refresh yet
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        // If already refreshing, queue this request
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then((token) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            return apiClient(originalRequest);
+          })
+          .catch((err) => Promise.reject(err));
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      const refreshToken = localStorage.getItem('refreshToken');
+      if (!refreshToken) {
+        // No refresh token available, logout user
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
+        return Promise.reject(error);
+      }
+
+      try {
+        const response = await axios.post(
+          `${import.meta.env.VITE_API_BASE_URL}/auth/refresh/`,
+          { refresh: refreshToken }
+        );
+        const { access } = response.data;
+        localStorage.setItem('accessToken', access);
+        apiClient.defaults.headers.common.Authorization = `Bearer ${access}`;
+        originalRequest.headers.Authorization = `Bearer ${access}`;
+        processQueue(null, access);
+        return apiClient(originalRequest);
+      } catch (refreshError) {
+        // Refresh failed, logout user
+        processQueue(refreshError, null);
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;

--- a/frontend/src/api/auth.api.ts
+++ b/frontend/src/api/auth.api.ts
@@ -1,1 +1,31 @@
-// Authentication API calls
+import apiClient from './apiClient';
+
+export interface User {
+  id: number;
+  email: string;
+  name: string;
+  role: 'ADMIN' | 'VOLUNTEER';
+  created_at: string;
+}
+
+export const authApi = {
+  login: async (email: string, password: string) => {
+    if (typeof email !== 'string' || email.trim().length === 0) {
+      throw new Error('Email is required and must be a non-empty string.');
+    }
+    if (typeof password !== 'string' || password.trim().length === 0) {
+      throw new Error('Password is required and must be a non-empty string.');
+    }
+    const response = await apiClient.post('/auth/login/', { email, password });
+    return response.data;
+  },
+
+  logout: async (refreshToken: string) => {
+    await apiClient.post('/auth/logout/', { refresh: refreshToken });
+  },
+
+  getCurrentUser: async (): Promise<User> => {
+    const response = await apiClient.get('/users/me/');
+    return response.data as User;
+  },
+};

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '../contexts';
+import ProtectedRoute from './ProtectedRoute';
+
+vi.mock('../api/auth.api', () => {
+  return {
+    authApi: {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+    },
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    Navigate: ({ to, replace }: { to: string; replace: boolean }) => {
+      mockNavigate(to, { replace });
+      return <div data-testid="navigate">{to}</div>;
+    },
+  };
+});
+
+const { authApi } = await import('../api/auth.api');
+type MockedAuthApi = {
+  login: Mock;
+  logout: Mock;
+  getCurrentUser: Mock;
+};
+const mockedAuthApi = authApi as unknown as MockedAuthApi;
+
+function renderProtectedRoute(children: React.ReactNode, requiredRole?: 'ADMIN' | 'VOLUNTEER') {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <BrowserRouter>
+        <AuthProvider>
+          <ProtectedRoute requiredRole={requiredRole}>{children}</ProtectedRoute>
+        </AuthProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockNavigate.mockClear();
+  mockedAuthApi.login.mockReset();
+  mockedAuthApi.logout.mockReset();
+  mockedAuthApi.getCurrentUser.mockReset();
+});
+
+describe('ProtectedRoute', () => {
+  it('redirects to /login when not authenticated', () => {
+    mockedAuthApi.getCurrentUser.mockResolvedValue(null);
+
+    renderProtectedRoute(<div>Protected Content</div>);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
+  });
+
+  it('shows loading state while checking authentication', () => {
+    localStorage.setItem('accessToken', 'token123');
+    mockedAuthApi.getCurrentUser.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(null), 1000))
+    );
+
+    renderProtectedRoute(<div>Protected Content</div>);
+
+    expect(screen.getByText('Loading...')).toBeTruthy();
+  });
+
+  it('redirects VOLUNTEER to / when ADMIN role required', async () => {
+    localStorage.setItem('accessToken', 'token123');
+    mockedAuthApi.getCurrentUser.mockResolvedValue({
+      id: 2,
+      email: 'volunteer@example.com',
+      name: 'Volunteer',
+      role: 'VOLUNTEER',
+      created_at: 'now',
+    });
+
+    renderProtectedRoute(<div>Admin Content</div>, 'ADMIN');
+
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+    });
+  });
+
+  it('allows ADMIN to access content when ADMIN role required', async () => {
+    localStorage.setItem('accessToken', 'token123');
+    mockedAuthApi.getCurrentUser.mockResolvedValue({
+      id: 1,
+      email: 'admin@example.com',
+      name: 'Admin',
+      role: 'ADMIN',
+      created_at: 'now',
+    });
+
+    renderProtectedRoute(<div>Admin Dashboard</div>, 'ADMIN');
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Admin Dashboard')).toBeTruthy();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('allows VOLUNTEER to access content when VOLUNTEER role required', async () => {
+    localStorage.setItem('accessToken', 'token123');
+    mockedAuthApi.getCurrentUser.mockResolvedValue({
+      id: 2,
+      email: 'volunteer@example.com',
+      name: 'Volunteer',
+      role: 'VOLUNTEER',
+      created_at: 'now',
+    });
+
+    renderProtectedRoute(<div>Welcome to the Collection Catalog</div>, 'VOLUNTEER');
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Welcome to the Collection Catalog')).toBeTruthy();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,27 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../contexts';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  requiredRole?: 'ADMIN' | 'VOLUNTEER';
+}
+
+const ProtectedRoute = ({ children, requiredRole }: ProtectedRouteProps) => {
+  const { isAuthenticated, isLoading, user } = useAuth();
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (requiredRole && user?.role !== requiredRole) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/contexts/AuthContext.shared.ts
+++ b/frontend/src/contexts/AuthContext.shared.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from 'react';
+import type { User } from '../api/auth.api';
+
+export interface AuthContextType {
+  user: User | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  isVolunteer: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  loginError: string | null;
+  logoutError: string | null;
+  isLoggingIn: boolean;
+  isLoggingOut: boolean;
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren } from 'react';
+import { AuthProvider } from '../contexts';
+import { useAuth } from './AuthContext.shared';
+
+vi.mock('../api/auth.api', () => {
+  return {
+    authApi: {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+    },
+  };
+});
+
+const { authApi } = await import('../api/auth.api');
+type MockedAuthApi = {
+  login: Mock;
+  logout: Mock;
+  getCurrentUser: Mock;
+};
+const mockedAuthApi = authApi as unknown as MockedAuthApi;
+
+function renderAuthHook() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={client}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+  return renderHook(() => useAuth(), { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockedAuthApi.login.mockReset();
+  mockedAuthApi.logout.mockReset();
+  mockedAuthApi.getCurrentUser.mockReset();
+});
+
+describe('AuthContext', () => {
+  it('session persists when accessToken exists', async () => {
+    localStorage.setItem('accessToken', 'access123');
+    mockedAuthApi.getCurrentUser.mockResolvedValue({ id: 3, email: 'x@y.com', name: 'User', role: 'VOLUNTEER', created_at: 'now' });
+
+    const { result } = renderAuthHook();
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(result.current.isVolunteer).toBe(true);
+  });
+
+  it('logout clears tokens', async () => {
+    localStorage.setItem('accessToken', 'access123');
+    localStorage.setItem('refreshToken', 'refresh123');
+    mockedAuthApi.getCurrentUser.mockResolvedValue({ id: 3, email: 'x@y.com', name: 'User', role: 'VOLUNTEER', created_at: 'now' });
+    mockedAuthApi.logout.mockResolvedValue(undefined);
+
+    const { result } = renderAuthHook();
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(localStorage.getItem('accessToken')).toBeNull();
+    expect(localStorage.getItem('refreshToken')).toBeNull();
+  });
+});

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,1 +1,44 @@
-// Authentication context and provider
+import { type ReactNode } from 'react';
+import { AuthContext, type AuthContextType } from './AuthContext.shared';
+import { useLogin, useLogout, useCurrentUser } from '../actions/useAuth';
+
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const loginMutation = useLogin();
+  const logoutMutation = useLogout();
+  const { data: user, isLoading: isLoadingUser } = useCurrentUser();
+  const isAuthenticated = !!user;
+  const isAdmin = user?.role === 'ADMIN';
+  const isVolunteer = user?.role === 'VOLUNTEER';
+
+  const login = async (email: string, password: string) => {
+    await loginMutation.mutateAsync({ email, password });
+  };
+
+  const logout = async () => {
+    await logoutMutation.mutateAsync();
+  };
+
+  const getErrorMessage = (error: unknown): string => {
+    if (error instanceof Error) return error.message;
+    if (typeof error === 'string') return error;
+    return 'An unexpected error occurred';
+  };
+
+  const value: AuthContextType = {
+    user: user || null,
+    isLoading: isLoadingUser,
+    isAuthenticated,
+    isAdmin,
+    isVolunteer,
+    login,
+    logout,
+    loginError: loginMutation.error ? getErrorMessage(loginMutation.error) : null,
+    logoutError: logoutMutation.error ? getErrorMessage(logoutMutation.error) : null,
+    isLoggingIn: loginMutation.isPending,
+    isLoggingOut: logoutMutation.isPending,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+

--- a/frontend/src/contexts/index.ts
+++ b/frontend/src/contexts/index.ts
@@ -1,1 +1,3 @@
 // Export all contexts
+export { AuthProvider } from './AuthContext';
+export { useAuth } from './AuthContext.shared';

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren } from 'react';
+import { AuthProvider } from '../contexts';
+import LoginPage from './LoginPage';
+
+// Mock auth API
+vi.mock('../api/auth.api', () => {
+  return {
+    authApi: {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+    },
+  };
+});
+
+// Mock react-router navigate
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+// Helpers
+function renderWithProviders(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={client}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+  return render(ui, { wrapper: Wrapper });
+}
+
+const { authApi } = await import('../api/auth.api');
+type MockedAuthApi = {
+  login: Mock;
+  logout: Mock;
+  getCurrentUser: Mock;
+};
+const mockedAuthApi = authApi as unknown as MockedAuthApi;
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  localStorage.clear();
+  mockedAuthApi.login.mockReset();
+  mockedAuthApi.getCurrentUser.mockReset();
+});
+
+describe('LoginPage', () => {
+  it('logs in ADMIN and redirects to /admin', async () => {
+    mockedAuthApi.login.mockResolvedValue({ access: 'access123', refresh: 'refresh123' });
+    mockedAuthApi.getCurrentUser.mockResolvedValue({ id: 1, email: 'admin@example.com', name: 'Admin', role: 'ADMIN', created_at: 'now' });
+
+    renderWithProviders(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'admin@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/admin'));
+  });
+
+  it('logs in VOLUNTEER and redirects to /', async () => {
+    mockedAuthApi.login.mockResolvedValue({ access: 'access123', refresh: 'refresh123' });
+    mockedAuthApi.getCurrentUser.mockResolvedValue({ id: 2, email: 'volunteer@example.com', name: 'Volunteer', role: 'VOLUNTEER', created_at: 'now' });
+
+    renderWithProviders(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'volunteer@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/'));
+  });
+
+  it('shows error on invalid credentials', async () => {
+    mockedAuthApi.login.mockRejectedValue(new Error('Invalid credentials'));
+
+    renderWithProviders(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'bad@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => expect(screen.getByText(/invalid credentials/i)).toBeInTheDocument());
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects already authenticated ADMIN away from login page', async () => {
+    localStorage.setItem('accessToken', 'access123');
+    mockedAuthApi.getCurrentUser.mockResolvedValue({ id: 1, email: 'admin@example.com', name: 'Admin', role: 'ADMIN', created_at: 'now' });
+
+    renderWithProviders(<LoginPage />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/admin'));
+  });
+
+  it('redirects already authenticated VOLUNTEER away from login page', async () => {
+    localStorage.setItem('accessToken', 'access123');
+    mockedAuthApi.getCurrentUser.mockResolvedValue({ id: 2, email: 'volunteer@example.com', name: 'Volunteer', role: 'VOLUNTEER', created_at: 'now' });
+
+    renderWithProviders(<LoginPage />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/'));
+  });
+});

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,87 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts';
+
+const LoginPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const { login, isLoggingIn, user, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isAuthenticated && user) {
+      navigate(user.role === 'ADMIN' ? '/admin' : '/');
+    }
+  }, [isAuthenticated, user, navigate]);
+
+  useEffect(() => {
+    if (hasSubmitted && isAuthenticated && user) {
+      navigate(user.role === 'ADMIN' ? '/admin' : '/');
+    }
+  }, [hasSubmitted, isAuthenticated, user, navigate]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setHasSubmitted(true);
+
+    try {
+      await login(email, password);
+    } catch (err) {
+      const errorMessage = 
+        err instanceof Error ? err.message : 'Login failed. Please check your credentials.';
+      setError(errorMessage);
+      setHasSubmitted(false);
+    }
+  };
+
+  return (
+    <div className="login-container">
+        <h1>Login</h1>
+
+        {error && (
+          <div className="error-message" role="alert" aria-live="polite">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="login-form">
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={isLoggingIn}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              disabled={isLoggingIn}
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isLoggingIn}
+            className="login-button"
+          >
+            {isLoggingIn ? 'Logging in...' : 'Login'}
+          </button>
+        </form>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/LogoutPage.test.tsx
+++ b/frontend/src/pages/LogoutPage.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '../contexts';
+import LogoutPage from './LogoutPage';
+
+vi.mock('../api/auth.api', () => {
+  return {
+    authApi: {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getCurrentUser: vi.fn(),
+    },
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const { authApi } = await import('../api/auth.api');
+type MockedAuthApi = {
+  login: Mock;
+  logout: Mock;
+  getCurrentUser: Mock;
+};
+const mockedAuthApi = authApi as unknown as MockedAuthApi;
+
+function renderLogoutPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <BrowserRouter>
+        <AuthProvider>
+          <LogoutPage />
+        </AuthProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockNavigate.mockClear();
+  mockedAuthApi.login.mockReset();
+  mockedAuthApi.logout.mockReset();
+  mockedAuthApi.getCurrentUser.mockReset();
+});
+
+describe('LogoutPage', () => {
+  it('calls logout function on mount', async () => {
+    localStorage.setItem('accessToken', 'access123');
+    localStorage.setItem('refreshToken', 'refresh123');
+    mockedAuthApi.logout.mockResolvedValue(undefined);
+
+    renderLogoutPage();
+
+    await waitFor(() => {
+      expect(mockedAuthApi.logout).toHaveBeenCalledWith('refresh123');
+    });
+  });
+
+  it('navigates to /login after logout', async () => {
+    localStorage.setItem('accessToken', 'access123');
+    localStorage.setItem('refreshToken', 'refresh123');
+    mockedAuthApi.logout.mockResolvedValue(undefined);
+
+    renderLogoutPage();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
+    });
+  });
+
+  it('clears tokens from localStorage', async () => {
+    localStorage.setItem('accessToken', 'access123');
+    localStorage.setItem('refreshToken', 'refresh123');
+    mockedAuthApi.logout.mockResolvedValue(undefined);
+
+    renderLogoutPage();
+
+    await waitFor(() => {
+      expect(localStorage.getItem('accessToken')).toBeNull();
+      expect(localStorage.getItem('refreshToken')).toBeNull();
+    });
+  });
+
+  it('displays logging out message', () => {
+    mockedAuthApi.logout.mockResolvedValue(undefined);
+    const { getByText } = renderLogoutPage();
+
+    expect(getByText('Logging out...')).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/LogoutPage.tsx
+++ b/frontend/src/pages/LogoutPage.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts';
+
+const LogoutPage = () => {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const hasLoggedOut = useRef(false);
+
+  useEffect(() => {
+    if (hasLoggedOut.current) return;
+    
+    hasLoggedOut.current = true;
+    
+    const performLogout = async () => {
+      try {
+        await logout();
+      } catch (error) {
+        console.error('Failed to log out:', error);
+      } finally {
+        navigate('/login', { replace: true });
+      }
+    };
+
+    performLogout();
+  }, [logout, navigate]);
+
+  return (
+    <div className="logout-container">
+      <p>Logging out...</p>
+    </div>
+  );
+};
+
+export default LogoutPage;


### PR DESCRIPTION
### Summary
Creates the frontend login experience for admins and volunteers.

### Related Issues
- Closes #4 

### Changes
- Login page with email/password fields
-` POST /api/auth/login` → store JWT or session token
- Redirect based on role (ADMIN → dashboard, VOLUNTEER → home)
- Logout clears token and redirects to login

### How to Test
1. Test login at `http://localhost:5173/login`
2. Verify redirect to `/admin` (ADMIN) or `/` (VOLUNTEER)
3. Test logout at `http://localhost:5173/logout` (redirects to login)
4. Verify `/admin` is inaccessible without authentication
5. Run tests: npm test

### Screenshots / UI
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4fcdc179-c492-412a-b1ec-0631949ac4d5" />

### Checklist
- [x] Tests added or updated
- [x] CI passes (lint, tests, build)
- [x] Documentation updated (if behavior changed)
- [x] No secrets or credentials committed