### PR TITLE
feat(catalogue): add public collections endpoint api rebased ver

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -144,6 +144,8 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",  # Or JWT
     ],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
 }
 
 SIMPLE_JWT = {

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("api/", include("users.urls")),
     # path('api/inventory/', include('inventory.urls')),
     # path('api/', include('requests.urls')),
+    path("api/", include("inventory.urls")),
 ]
 
 # Example API Structure:

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -1,26 +1,46 @@
 from rest_framework import serializers
+from .models import CollectionItem, Location
 
-# from .models import InventoryItem
 
-# Create your serializers here.
+class LocationSerializer(serializers.ModelSerializer):
+    """
+    Nested serializer for Location model.
+    Used to show location details in public API responses.
+    """
 
-# Example: InventoryItem Serializer
-# Uncomment and modify as needed
-#
-# class InventoryItemSerializer(serializers.ModelSerializer):
-#     """
-#     Serializer for the InventoryItem model.
-#     Handles conversion between model instances and JSON.
-#     """
-#     created_by_username = serializers.CharField(source='created_by.username', read_only=True)
-#
-#     class Meta:
-#         model = InventoryItem
-#         fields = '__all__'  # Or specify: ['id', 'name', 'quantity', ...]
-#         read_only_fields = ['id', 'created_at', 'updated_at', 'created_by']
-#
-#     def validate_quantity(self, value):
-#         """Custom validation for quantity field."""
-#         if value < 0:
-#             raise serializers.ValidationError("Quantity cannot be negative.")
-#         return value
+    location_type_display = serializers.CharField(source="get_location_type_display", read_only=True)
+
+    class Meta:
+        model = Location
+        fields = ["id", "name", "location_type", "location_type_display", "description"]
+        read_only_fields = ["id", "name", "location_type", "location_type_display", "description"]
+
+
+class PublicCollectionItemSerializer(serializers.ModelSerializer):
+    """
+    Serializer for public-facing collection items.
+    Exposes read-only collection data without internal fields.
+    """
+
+    current_location = LocationSerializer(read_only=True)
+
+    class Meta:
+        model = CollectionItem
+        fields = [
+            "id",
+            "item_code",
+            "title",
+            "platform",
+            "description",
+            "is_on_floor",
+            "current_location",
+        ]
+        read_only_fields = [
+            "id",
+            "item_code",
+            "title",
+            "platform",
+            "description",
+            "is_on_floor",
+            "current_location",
+        ]

--- a/backend/inventory/urls.py
+++ b/backend/inventory/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
+from .views import PublicCollectionItemViewSet
 
 # from .views import InventoryItemViewSet
 
@@ -24,4 +25,9 @@ from rest_framework.routers import DefaultRouter
 # DELETE /api/inventory/items/{id}/      - Delete an item
 # GET    /api/inventory/items/low_stock/ - Custom action (if defined)
 
-urlpatterns = []
+router = DefaultRouter()
+router.register(r"items", PublicCollectionItemViewSet, basename="public-item")
+
+urlpatterns = [
+    path("public/", include(router.urls)),
+]

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -1,38 +1,47 @@
-from rest_framework import viewsets, permissions, filters, status
-from rest_framework.decorators import action
-from rest_framework.response import Response
+from rest_framework import viewsets, permissions, filters
+from .models import CollectionItem
+from .serializers import PublicCollectionItemSerializer
 
-# from .models import InventoryItem
-# from .serializers import InventoryItemSerializer
 
-# Create your views here.
+class PublicCollectionItemViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Public-facing ViewSet for collection items.
+    Provides read-only access to public catalogue with filtering and search.
 
-# Example: InventoryItem ViewSet
-# Uncomment and modify as needed
-#
-# class InventoryItemViewSet(viewsets.ModelViewSet):
-#     """
-#     ViewSet for managing inventory items.
-#     Provides full CRUD + filtering and search capabilities.
-#     """
-#     queryset = InventoryItem.objects.all()
-#     serializer_class = InventoryItemSerializer
-#     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-#     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
-#     search_fields = ['name', 'description', 'category']
-#     ordering_fields = ['name', 'quantity', 'created_at']
-#
-#     def perform_create(self, serializer):
-#         """Automatically set created_by to current user."""
-#         serializer.save(created_by=self.request.user)
-#
-#     @action(detail=False, methods=['get'])
-#     def low_stock(self, request):
-#         """
-#         Custom endpoint: GET /api/inventory/items/low_stock/
-#         Returns items with low quantity.
-#         """
-#         # Example: items with quantity less than 10
-#         low_items = self.queryset.filter(quantity__lt=10)
-#         serializer = self.get_serializer(low_items, many=True)
-#         return Response(serializer.data)
+    Endpoints:
+    - GET /api/public/items/ - List all public items (with filtering/search)
+    - GET /api/public/items/{id}/ - Retrieve single public item
+    """
+
+    queryset = CollectionItem.objects.filter(is_public_visible=True).select_related("current_location")
+    serializer_class = PublicCollectionItemSerializer
+    permission_classes = [permissions.AllowAny]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ["title", "description", "item_code"]
+    ordering_fields = ["title", "platform", "created_at"]
+
+    def get_queryset(self):
+        """
+        Filter queryset based on query parameters.
+        Supports filtering by platform and is_on_floor.
+        """
+        # Get base queryset from parent class (uses self.queryset from line 18)
+        queryset = super().get_queryset()
+
+        # Filter by platform if provided
+        platform = self.request.query_params.get("platform", None)
+        if platform:
+            queryset = queryset.filter(platform=platform)
+
+        # Filter by is_on_floor if provided
+        is_on_floor = self.request.query_params.get("is_on_floor", None)
+        if is_on_floor is not None:
+            # Normalize and convert string to boolean with explicit handling
+            is_on_floor_str = is_on_floor.strip().lower()
+            if is_on_floor_str in ("false", "0", "no"):
+                queryset = queryset.filter(is_on_floor=False)
+            elif is_on_floor_str in ("true", "1", "yes"):
+                queryset = queryset.filter(is_on_floor=True)
+            # Invalid value: skip filtering on is_on_floor (ignore invalid input)
+
+        return queryset

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -7,6 +7,7 @@ addopts =
     --verbose
     --strict-markers
     --tb=short
+    --cov=inventory
     --cov-report=term-missing
     --cov-report=html
 testpaths = .


### PR DESCRIPTION
### Note
#19 was the original PR for this issue, this PR was opened instead due to rebasing conflicts with the previous one.

### Summary
Implements public-facing read-only API endpoints for the collection catalogue. Allows public users to browse and search collection items without authentication.

### Related Issues
- Closes #8 

### Changes
- Added `PublicCollectionItemSerializer` with nested location data
- Created `PublicCollectionItemViewSet` with filtering and search capabilities
- Added URL routing for `/api/public/items/` endpoints
- Implemented filtering by platform and is_on_floor
- Added text search across title, description, and item_code
- Excluded items where `is_public_visible=False`
- Added unit tests to API using Django's TestCase
- Added documentation for api use

### How to Test
1. Start the backend server:sh
   cd backend
   source venv/bin/activate
2.  Run tests:
   pytest inventory/tests.py  

   ### Checklist
- [x] Public can view items and filter/search correctly
- [x] Hidden items never appear
- [x] Pagination and search work smoothly