### PR TITLE
feat(catalogue): public catalogue UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import HomePage from './pages/public/HomePage';
 import LoginPage from './pages/LoginPage';
 import LogoutPage from './pages/LogoutPage';
 import AdminDashboard from './pages/admin/AdminDashboard';
+import CataloguePage from './pages/public/CataloguePage';
 
 
 const queryClient = new QueryClient();
@@ -21,6 +22,7 @@ const App: React.FC = () => {
             {/* --- Public Routes --- */}
             <Route path="/" element={<HomePage />} />
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/catalogue" element={<CataloguePage/>} />
             <Route path="/logout" element={<LogoutPage />} />
 
             {/* --- Admin Routes --- */}

--- a/frontend/src/actions/index.ts
+++ b/frontend/src/actions/index.ts
@@ -1,2 +1,3 @@
 // Export all hooks
+export * from './useItems';
 export { useVolunteerApplications, useUpdateVolunteerStatus } from './useVolunteers';

--- a/frontend/src/actions/useItems.ts
+++ b/frontend/src/actions/useItems.ts
@@ -1,1 +1,11 @@
-// Collection Items hooks
+import { useQuery } from '@tanstack/react-query';
+import { itemsApi } from '../api/items.api';
+import type { ItemFilter } from '../lib/filters';
+
+// Hook to fetch all public items
+export const useItems = (filters?: ItemFilter) => {
+  return useQuery({
+    queryKey: ['items', 'list', filters],
+    queryFn: () => itemsApi.getAll(filters),
+  });
+};

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,2 +1,3 @@
 // Export all API services
-export { default as apiClient } from './apiClient'
+export { default as apiClient } from './apiClient';
+export * from './items.api';

--- a/frontend/src/api/items.api.ts
+++ b/frontend/src/api/items.api.ts
@@ -1,1 +1,18 @@
 // Collection Items API calls
+import apiClient from './apiClient';
+import type { PublicCollectionItem } from '../lib/types';
+import type { ItemFilter } from '../lib/filters';
+
+export const itemsApi = {
+  getAll: async (params?: ItemFilter): Promise<PublicCollectionItem[]> => {
+    const queryParams: Record<string, string> = {};
+    if (params?.platform) queryParams.platform = params.platform;
+    if (params?.is_on_floor !== undefined && params?.is_on_floor !== null)
+      queryParams.is_on_floor = params.is_on_floor ? 'true' : 'false';
+    if (params?.search) queryParams.search = params.search;
+    if (params?.ordering) queryParams.ordering = params.ordering;
+
+    const response = await apiClient.get<PublicCollectionItem[]>('/public/items/', { params: queryParams });
+    return response.data;
+  }
+};

--- a/frontend/src/components/items/CatalogueSearchBar.tsx
+++ b/frontend/src/components/items/CatalogueSearchBar.tsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import { CATALOGUE_ORDERING_OPTIONS } from '../../lib/constants';
+import type { ItemFilter } from '../../lib/filters';
+
+interface SearchBarProps {
+  filters: ItemFilter;
+  setFilters: React.Dispatch<React.SetStateAction<ItemFilter>>;
+}
+
+const CatalogueSearchBar: React.FC<SearchBarProps> = ({ filters, setFilters }) => {
+
+  const [searchValue, setSearchValue] = useState(filters.search ?? '');
+
+  useEffect(() => { // debounce the search feature
+    const handler = setTimeout(() => {
+      setFilters((prev) => ({
+        ...prev,
+        search: searchValue.trim() || null
+      }));
+    }, 300);
+
+    return () => clearTimeout(handler);
+  }, [searchValue, setFilters]);
+
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.trim();
+    setSearchValue(value);
+  };
+
+  const handlePlatformChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value.trim();
+    setFilters(prev => ({ ...prev, platform: value || null }));
+  };
+
+  const handleFloorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilters(prev => ({
+      ...prev,
+      is_on_floor: e.target.checked ? true : null,
+    }));
+  };
+
+  const handleOrderingChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value.trim();
+    setFilters(prev => ({ ...prev, ordering: value || null }));
+  };
+
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        maxWidth: '600px',
+        width: '100%',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="catalogue-search-input" style={{ fontSize: '14px' }}>
+          Search items
+        </label>
+        <input
+          id="catalogue-search-input"
+          type="text"
+          placeholder="Search items..."
+          value={searchValue}
+          onChange={handleSearchChange}
+          style={{
+            width: '100%',
+            padding: '10px 12px',
+            fontSize: '16px',
+            borderRadius: '6px',
+            border: '1px solid #ccc',
+          }}
+        />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="catalogue-platform-select" style={{ fontSize: '14px' }}>
+          Platform
+        </label>
+        <select
+          id="catalogue-platform-select"
+          value={filters.platform ?? ''}
+          onChange={handlePlatformChange}
+          style={{
+            padding: '10px 12px',
+            fontSize: '16px',
+            borderRadius: '6px',
+            border: '1px solid #ccc',
+          }}
+        >
+          <option value="">All Platforms</option>
+          <option value="PC">PC</option>
+          <option value="Switch">Switch</option>
+          <option value="Xbox">Xbox</option>
+          <option value="PS5">PS5</option>
+        </select>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="catalogue-ordering-select" style={{ fontSize: '14px' }}>
+          Sort by
+        </label>
+        <select
+          id="catalogue-ordering-select"
+          value={filters.ordering ?? ''}
+          onChange={handleOrderingChange}
+          style={{
+            padding: '10px 12px',
+            fontSize: '16px',
+            borderRadius: '6px',
+            border: '1px solid #ccc',
+          }}
+        >
+          <option value="">Default Order</option>
+          {CATALOGUE_ORDERING_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '16px' }}>
+        <input
+          type="checkbox"
+          checked={filters.is_on_floor ?? false}
+          onChange={handleFloorChange}
+        />
+        On Floor
+      </label>
+    </div>
+  );
+}
+
+export default CatalogueSearchBar;

--- a/frontend/src/components/items/ItemCard.tsx
+++ b/frontend/src/components/items/ItemCard.tsx
@@ -1,1 +1,27 @@
 // Item card component
+import type { PublicCollectionItem } from "../../lib/types"
+
+interface ItemCardProps {
+  item: PublicCollectionItem;
+}
+
+const ItemCard: React.FC<ItemCardProps> = ({ item }) => {
+  return (
+    <div style={{
+      border: "1px solid #ccc",
+      padding: "12px",
+      borderRadius: "8px",
+      marginBottom: "12px",
+      maxWidth: "20em"
+    }}>
+      <p><strong>ID:</strong> {item.id}</p>
+      <p><strong>Item Code:</strong> {item.item_code}</p>
+      <p><strong>Title:</strong> {item.title}</p>
+      <p><strong>Platform:</strong> {item.platform}</p>
+      <p><strong>Description:</strong> {item.description}</p>
+      <p><strong>On Floor:</strong> {item.is_on_floor ? "Yes" : "No"}</p>
+    </div>
+  );
+}
+
+export default ItemCard;

--- a/frontend/src/components/items/ItemList.tsx
+++ b/frontend/src/components/items/ItemList.tsx
@@ -1,1 +1,28 @@
 // Item list component
+// Item list component
+
+import type { PublicCollectionItem } from "../../lib/types";
+import ItemCard from "./ItemCard";
+
+interface ItemListProps {
+    items: PublicCollectionItem[];
+}
+
+const ItemList: React.FC<ItemListProps> = ({items}) => {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
+        gap: "1rem",
+        maxWidth: "100%",
+      }}
+    >
+      {items.map((item) => (
+        <ItemCard key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+export default ItemList;

--- a/frontend/src/components/items/index.ts
+++ b/frontend/src/components/items/index.ts
@@ -1,2 +1,5 @@
 // Export item components
+export {default as CatalogueSearchBar} from './CatalogueSearchBar'
+export {default as ItemCard} from './ItemCard'
+export {default as ItemList} from './ItemList'
 export { default as VolunteerList } from './VolunteerList';

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,1 +1,9 @@
 // Application constants
+export const CATALOGUE_ORDERING_OPTIONS = [
+  { label: "Name A → Z", value: "title" },
+  { label: "Name Z → A", value: "-title" },
+  { label: "Platform A → Z", value: "platform" },
+  { label: "Platform Z → A", value: "-platform" },
+  { label: "Oldest → Newest", value: "created_at" },
+  { label: "Newest → Oldest", value: "-created_at" },
+];

--- a/frontend/src/lib/filters.ts
+++ b/frontend/src/lib/filters.ts
@@ -1,0 +1,6 @@
+export interface ItemFilter {
+  search?: string | null;
+  platform?: string | null;
+  is_on_floor?: boolean | null;
+  ordering?: string | null;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -30,6 +30,15 @@ export interface CollectionItem {
   description: string;
 }
 
+export interface PublicCollectionItem {
+  id: number;
+  item_code: string;
+  title: string;
+  platform: string;
+  description: string;
+  is_on_floor: boolean;
+}
+
 // TODO: place holder
 export interface ItemOnFloor {
   id: number;

--- a/frontend/src/pages/public/CataloguePage.tsx
+++ b/frontend/src/pages/public/CataloguePage.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { useItems } from '../../actions';
+import type { ItemFilter } from '../../lib/filters';
+import { CatalogueSearchBar, ItemList } from '../../components/items'
+
+const CataloguePage: React.FC = () => {
+
+  const [filters, setFilters] = useState<ItemFilter>({
+    search: null,
+    platform: null,
+    is_on_floor: null,
+    ordering: null,
+  });
+
+  const { data: items = [], isLoading, isError } = useItems(filters);
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Welcome to the Collection Catalog</h1>
+      <p>Browse our available items and see what's currently on the floor.</p>
+      <div className="search-filter-section" style={{ margin: '2rem 0', width: "auto" }}>
+        <h2>Search & Filter</h2>
+        <CatalogueSearchBar filters={filters} setFilters={setFilters} />
+      </div>
+      <div className="catalog-results-section">
+        <h2>Collection Items</h2>
+        {isLoading && <p>Loading items...</p>}
+        {isError && <p>Failed to load items.</p>}Expand commentComment on line R27Resolved
+        {!isLoading && items?.length === 0 && <p>No items found.</p>}
+        {items && items.length > 0 && <ItemList items={items} />}
+      </div>
+    </div>
+  );
+};
+
+export default CataloguePage;


### PR DESCRIPTION
### Note
#22 was the original PR for this issue, this PR was opened instead due to rebasing conflicts with the previous one.

### Summary

Adds the basic component for admin to view volunteers and reject and approve volunteer applications.

Sets up basic API interface to access public read endpoints for items, and defines simple starting components for catalogue UI.

### Related Issues
Relates to #19 as it pulls data from the defined endpoint.
Closes #9.

### Changes

Adds useItems hook and API pathway for /public/items
Added basic component design for ItemCard and ItemList using CSS grid
Introduced shared search bar component with filters and API refreshment upon filter change

### Testing
Currently not testable with public items API endpoint as it is still a work in progress at #19. 

### Screenshots / UI (if applicable)
After:

<img width="664" height="734" alt="image" src="https://github.com/user-attachments/assets/f4b7985d-3a89-4fe2-adfa-b7444df9dd57" />
